### PR TITLE
Alpha 0.1.2 Release Merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,29 @@ Golang Struct Relation Diagram
 ## To-Do
 
 - [ ] walk ast doc for structs in files from dir and create config file `alpha-0.?.?`
-    - [ ] create dry-run flag (generate txt output)
-        - [ ] refine text output `alpha-0.1.?`
-        - [ ] create flag `alpha-0.1.?`
-        - [ ] create logic for flag `alpha-0.1.?`
+    - [ ] create dry-run flag (generate txt output) `alpha-0.1.3`
+        - [ ] refine text output `alpha-0.1.3`
+        - [ ] create flag `alpha-0.1.3`
+        - [ ] create logic for flag `alpha-0.1.3``
     - [ ] based on package type `alpha-0.1.?`
-    - [ ] output to config file (graphviz?) `alpha-0.1.?`
-        - [ ] decide on graphing library
+    - [ ] output to config file (graphviz) `alpha-0.1.3`
+        - [ ] decide on graphing library `alpha-0.1.3`
     - [ ] structs from other locations `alpha-0.1.?`
     - [x] allow external non StarExpr types to be recognized `alpha-0.1.2`
     - [x] implement zap logger `alpha-0.1.2`
-- [ ] use config to genereate graph  `beta-0.?.?`
+- [ ] use config to genereate graph  `alpha-0.1.?`
 - [x] add \*ast.FuncType and \*ast.SelectorExpr to aster.go `alpha-0.1.2`
 - [x] refactor processing for aster.go case statements to 'fieldType = someFunction(inputs)' `alpha-0.1.2`
 - [x] create aster.go func getUndeterminedType to reduce code redundancy `alpha-0.1.2`
-- [ ] fix getAstMapType to support all types for mtv `alpha-0.1.2`
+- [ ] finish fixing getAstMapType to support all types for mtv `alpha-0.1.?`
 - [x] fix aster.go to allow support for directly nested structs `alpha-0.1.2`
 - [x] add \*ast.ChanType to aster.go `alpha-0.1.2`
 
 ## Release Requirements
 
 - alpha-0.1.2:
-    - [ ] No bugs in running code
-    - [ ] Above labeled to-do's finished
+    - [x] No bugs in running code
+    - [x] Above labeled to-do's finished
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Golang Struct Relation Diagram
 - [x] create aster.go func getUndeterminedType to reduce code redundancy `alpha-0.1.2`
 - [ ] fix getAstMapType to support all types for mtv `alpha-0.1.2`
 - [ ] fix aster.go to allow support for directly nested structs `alpha-0.1.?`
+- [x] add \*ast.ChanType to aster.go `alpha-0.1.2`
 
 ## Release Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,25 +12,13 @@ Golang Struct Relation Diagram
     - [ ] output to config file (graphviz?) `alpha-0.1.?`
         - [ ] decide on graphing library
     - [ ] structs from other locations `alpha-0.1.?`
-    - [x] exclude golang test files `alpha-0.1.1`
-    - [x] create inter struct relations map `alpha-0.1.1`
-        - [x] internal structs
-        - [x] external structs
-            - [x] create a list of types using `*ast.TypeSpec` `alpha-0.1.1`
-                - break walkStructSpec into walkTypeSpec and walkStructSpec
-                - parse all types into list for reference by relations.go
-            - [x] parse external stucts on ?(StarExpr)
     - [ ] allow external non StarExpr types to be recognized `alpha-0.1.2`
-    - [x] organize data into structs `alpha-0.1.1`
-    - [x] decode parameter type names `alpha-0.1.1`
-    - [x] changed flag parser to require arguments `alpha-0.1.1`
-    - [x] need to parse for `*ast.MapType` on parameter values `alpha-0.1.1`
-        - `./bin/gophermap -p ../../atp/line-sender/ -a | grep -C 30 words | head -60`
     - [x] implement zap logger `alpha-0.1.2`
 - [ ] use config to genereate graph  `beta-0.?.?`
-- [x] add usage instructions `alpha-0.1.1`
-- [ ] add \*ast.FuncType and \*ast.SelectorExpr to aster.go `alpha-0.1.2`
+- [x] add \*ast.FuncType and \*ast.SelectorExpr to aster.go `alpha-0.1.2`
 - [x] refactor processing for aster.go case statements to 'fieldType = someFunction(inputs)' `alpha-0.1.2`
+- [x] create aster.go func getUndeterminedType to reduce code redundancy `alpha-0.1.2`
+- [ ] fix getAstMapType to support all types for mtv `alpha-0.1.2`
 
 ## Release Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Golang Struct Relation Diagram
     - [ ] output to config file (graphviz?) `alpha-0.1.?`
         - [ ] decide on graphing library
     - [ ] structs from other locations `alpha-0.1.?`
-    - [ ] allow external non StarExpr types to be recognized `alpha-0.1.2`
+    - [x] allow external non StarExpr types to be recognized `alpha-0.1.2`
     - [x] implement zap logger `alpha-0.1.2`
 - [ ] use config to genereate graph  `beta-0.?.?`
 - [x] add \*ast.FuncType and \*ast.SelectorExpr to aster.go `alpha-0.1.2`
 - [x] refactor processing for aster.go case statements to 'fieldType = someFunction(inputs)' `alpha-0.1.2`
 - [x] create aster.go func getUndeterminedType to reduce code redundancy `alpha-0.1.2`
 - [ ] fix getAstMapType to support all types for mtv `alpha-0.1.2`
-- [ ] fix aster.go to allow support for directly nested structs `alpha-0.1.?`
+- [x] fix aster.go to allow support for directly nested structs `alpha-0.1.2`
 - [x] add \*ast.ChanType to aster.go `alpha-0.1.2`
 
 ## Release Requirements

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Golang Struct Relation Diagram
     - [ ] based on package type `alpha-0.1.?`
     - [ ] output to config file (graphviz?) `alpha-0.1.?`
         - [ ] decide on graphing library
-    - [ ] structs from other locations `alpha-0.1.2`
+    - [ ] structs from other locations `alpha-0.1.?`
     - [x] exclude golang test files `alpha-0.1.1`
     - [x] create inter struct relations map `alpha-0.1.1`
         - [x] internal structs
@@ -26,13 +26,15 @@ Golang Struct Relation Diagram
     - [x] changed flag parser to require arguments `alpha-0.1.1`
     - [x] need to parse for `*ast.MapType` on parameter values `alpha-0.1.1`
         - `./bin/gophermap -p ../../atp/line-sender/ -a | grep -C 30 words | head -60`
-    - [ ] implement zap logger `alpha-0.1.2`
+    - [x] implement zap logger `alpha-0.1.2`
 - [ ] use config to genereate graph  `beta-0.?.?`
 - [x] add usage instructions `alpha-0.1.1`
+- [ ] add \*ast.FuncType and \*ast.SelectorExpr to aster.go `alpha-0.1.2`
+- [x] refactor processing for aster.go case statements to 'fieldType = someFunction(inputs)' `alpha-0.1.2`
 
 ## Release Requirements
 
-- alpha-0.1.1:
+- alpha-0.1.2:
     - [ ] No bugs in running code
     - [ ] Above labeled to-do's finished
 
@@ -52,4 +54,23 @@ Print structs + struct properties from all files in a project directory.
 Print ast file for debugging.
 ```bash
 ./bin/gophermap -p <path-to-project> -a
+```
+
+Print detailed debugging logs.
+```bash
+./bin/gophermap -p <path-to-project> -v
+```
+
+Bash function to search output ast file for a specific struct.
+```bash
+function getStruct {
+    if [ -z $GOPHERREPO ]; then
+        echo "Set path to gophermap repository to GOPHERREPO"
+    elif [ -z $1 ] || [ -z $2 ] || [ -z $3 ]; then
+        echo "USAGE: getStruct <struct-name> <output-length> <file-path>"
+    else
+        cd $GOPHERREPO
+        ./bin/gophermap -p $3 -v -a | grep -E -B 3 -A $2 "^[ ].*[0-9]  (\.  ){8}Name: \"$1\""
+    fi
+}
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Golang Struct Relation Diagram
 - [x] refactor processing for aster.go case statements to 'fieldType = someFunction(inputs)' `alpha-0.1.2`
 - [x] create aster.go func getUndeterminedType to reduce code redundancy `alpha-0.1.2`
 - [ ] fix getAstMapType to support all types for mtv `alpha-0.1.2`
+- [ ] fix aster.go to allow support for directly nested structs `alpha-0.1.?`
 
 ## Release Requirements
 

--- a/aster.go
+++ b/aster.go
@@ -28,6 +28,18 @@ type StructDef struct {
 //VisitorFunc function v1.0
 type VisitorFunc func(n ast.Node) ast.Visitor
 
+func appendTypeList(t string) {
+	var exists int
+	for _, item := range typeList {
+		if item == t {
+			exists = 1
+		}
+	}
+	if exists != 1 {
+		typeList = append(typeList, t)
+	}
+}
+
 //Visit function v1.0
 func (f VisitorFunc) Visit(n ast.Node) ast.Visitor {
 	return f(n)
@@ -57,7 +69,7 @@ func FindTypes(n ast.Node) ast.Visitor {
 }
 
 func walkTypeSpec(n *ast.TypeSpec) ast.Visitor {
-	typeList = append(typeList, n.Name.Name)
+	appendTypeList(n.Name.Name)
 	switch v := n.Type.(type) {
 	case *ast.StructType:
 		sugar.Debugf("Struct: %s", n.Name.Name)
@@ -99,6 +111,9 @@ func recordAstStructType(fn string, s *ast.StructType) (rv string) {
 		map[string]string{},
 		[]string{},
 	}
+
+	appendTypeList(fn)
+
 	for _, item := range s.Fields.List {
 		var fieldName string
 
@@ -118,7 +133,7 @@ func recordAstStructType(fn string, s *ast.StructType) (rv string) {
 
 		structMap[fn].Properties[fieldName] = fieldType
 	}
-	return "struct"
+	return fn
 }
 
 func getAstChanType(s *ast.ChanType) (rv string) {

--- a/aster.go
+++ b/aster.go
@@ -107,32 +107,25 @@ func walkStructSpec(n *ast.TypeSpec, v *ast.StructType) ast.Visitor {
 	return VisitorFunc(FindTypes)
 }
 
-func getAstStarExpr(s *ast.StarExpr) string {
-	var Sel string
-	var Name string
+func getAstStarExpr(s *ast.StarExpr) (rv string) {
 	switch se := s.X.(type) {
 	case *ast.SelectorExpr:
-		Sel = se.Sel.Name
-		switch ne := se.X.(type) {
-		case *ast.Ident:
-			Name = getAstIdent(ne)
-		}
+		rv = "*" + getAstSelectorExpr(se)
 	}
-	return "*" + Name + "." + Sel
+	return
 }
 
-func getAstMapType(s *ast.MapType) string {
+func getAstMapType(s *ast.MapType) (rv string) {
 	var mKey string
-	var mVal string
 	switch mtk := s.Key.(type) {
 	case *ast.Ident:
 		mKey = getAstIdent(mtk)
 	}
 	switch mtv := s.Value.(type) {
 	case *ast.Ident:
-		mVal = getAstIdent(mtv)
+		rv = "map[" + mKey + "]" + getAstIdent(mtv)
 	}
-	return "map[" + mKey + "]" + mVal
+	return
 }
 
 func getAstArrayType(s *ast.ArrayType) (rv string) {
@@ -145,9 +138,9 @@ func getAstArrayType(s *ast.ArrayType) (rv string) {
 
 func getAstSelectorExpr(s *ast.SelectorExpr) (rv string) {
 	Sel := s.Sel.Name
-	switch sele := s.X.(type) {
+	switch se := s.X.(type) {
 	case *ast.Ident:
-		rv = sele.Name + "." + Sel
+		rv = se.Name + "." + Sel
 	}
 	return
 }

--- a/aster.go
+++ b/aster.go
@@ -106,9 +106,30 @@ func getUndeterminedType(fi *ast.Field) (rv string) {
 		rv = getAstSelectorExpr(s)
 	case *ast.FuncType:
 		rv = getAstFuncType(s)
+	case *ast.ChanType:
+		rv = getAstChanType(s)
 	case *ast.Ident:
 		rv = getAstIdent(s)
 	}
+	return
+}
+
+func getAstChanType(s *ast.ChanType) (rv string) {
+	var tv string
+
+	switch se := s.Value.(type) {
+	case *ast.SelectorExpr:
+		tv = getAstSelectorExpr(se)
+	}
+
+	if s.Dir == ast.SEND {
+		rv = "chan" + "<-" + tv
+	} else if s.Dir == ast.RECV {
+		panic("Check AST Document Dir was not 1")
+	} else {
+		logger.Fatal("Unknown Error Invalid Chan Type")
+	}
+
 	return
 }
 
@@ -138,6 +159,8 @@ func getAstStarExpr(s *ast.StarExpr) (rv string) {
 	switch se := s.X.(type) {
 	case *ast.SelectorExpr:
 		rv = "*" + getAstSelectorExpr(se)
+	case *ast.Ident:
+		rv = "*" + getAstIdent(se)
 	}
 	return
 }
@@ -151,6 +174,10 @@ func getAstMapType(s *ast.MapType) (rv string) {
 	switch mtv := s.Value.(type) {
 	case *ast.Ident:
 		rv = "map[" + mKey + "]" + getAstIdent(mtv)
+	case *ast.ArrayType:
+		rv = "map[" + mKey + "]" + getAstArrayType(mtv)
+	case *ast.SelectorExpr:
+		rv = "map[" + mKey + "]" + getAstSelectorExpr(mtv)
 	}
 	return
 }
@@ -158,17 +185,17 @@ func getAstMapType(s *ast.MapType) (rv string) {
 func getAstArrayType(s *ast.ArrayType) (rv string) {
 	switch at := s.Elt.(type) {
 	case *ast.StarExpr:
-		rv = getAstStarExpr(at)
+		rv = "[]" + getAstStarExpr(at)
 	case *ast.MapType:
-		rv = getAstMapType(at)
+		rv = "[]" + getAstMapType(at)
 	case *ast.ArrayType:
-		rv = getAstArrayType(at)
+		rv = "[]" + getAstArrayType(at)
 	case *ast.SelectorExpr:
-		rv = getAstSelectorExpr(at)
+		rv = "[]" + getAstSelectorExpr(at)
 	case *ast.FuncType:
-		rv = getAstFuncType(at)
+		rv = "[]" + getAstFuncType(at)
 	case *ast.Ident:
-		rv = getAstIdent(at)
+		rv = "[]" + getAstIdent(at)
 	}
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,8 @@ module /home/procyclinsur/Documents/personal/gophermap
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/uber-go/zap v1.9.1
+	go.uber.org/atomic v1.3.2 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
+	go.uber.org/zap v1.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,11 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/uber-go/zap v1.9.1 h1:CZN7Pmty0PLtqZEi3N8VSI0Us8b0RL5ah6l1jOH3ZJ0=
+github.com/uber-go/zap v1.9.1/go.mod h1:GY+83l3yxBcBw2kmHu/sAWwItnTn+ynxHCRo+WiIQOY=
+go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
+go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
+go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/main.go
+++ b/main.go
@@ -11,18 +11,23 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	flags "github.com/jessevdk/go-flags"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
-	opts     Options
-	fset     *token.FileSet
-	pathList []string
-	//debug bool
+	opts      Options
+	fset      *token.FileSet
+	pathList  []string
+	logger    *zap.Logger
+	sugar     *zap.SugaredLogger
+	zapConfig zap.Config
 )
 
 //Options : Command Line Options
 type Options struct {
 	Path     string `short:"p" long:"path" description:"Project directory path" required:"true"`
+	Debug    bool   `short:"v" long:"verbose" description:"Print debug messages"`
 	AstDebug bool   `short:"a" long:"astdebug" description:"Print AST file"`
 	HelpFlag bool   `short:"h" long:"help" description:"Print this help message"`
 }
@@ -40,26 +45,83 @@ func init() {
 	} else if err != nil {
 		panic(err)
 	}
+
+	var logLevel zap.AtomicLevel
+	if opts.Debug != true {
+		logLevel = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	} else {
+		logLevel = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	}
+
+	var initialFields map[string]interface{}
+
+	zapConfig = zap.Config{
+		Level:             logLevel,
+		Development:       false,
+		DisableCaller:     false,
+		DisableStacktrace: true,
+		Sampling:          nil,
+		Encoding:          "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:     "msg",
+			LevelKey:       "type",
+			TimeKey:        "",
+			NameKey:        "",
+			CallerKey:      "src",
+			StacktraceKey:  "",
+			LineEnding:     "\n",
+			EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+			EncodeTime:     zapcore.EpochMillisTimeEncoder,
+			EncodeDuration: zapcore.NanosDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+			EncodeName:     zapcore.FullNameEncoder,
+		},
+		OutputPaths: []string{
+			"stdout",
+			"/tmp/logs",
+		},
+		ErrorOutputPaths: []string{
+			"stderr",
+		},
+		InitialFields: initialFields,
+	}
 }
 
 func main() {
+	logger, err := zapConfig.Build()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+	defer logger.Sync()
+	sugar = logger.Sugar()
+
+	//sugar.Infow("failed to fetch URL",
+	// Structured context as loosely typed key-value pairs.
+	//	"url", "http://example.com",
+	//	"attempt", 3,
+	//	"backoff", time.Second,
+	//)
+
+	logger.Info("Parsing project directory for golang files...")
 	if err := getPathList(opts.Path, visit); err != nil {
-		fmt.Printf("filepath.Walk() returned %v\n", err)
+		sugar.Errorf("filepath.Walk() returned %v\n", err)
 	}
 
 	fset = token.NewFileSet()
 
 	if opts.AstDebug != true {
+		logger.Info("Beginning AST Analysis...")
 		tl, sm := parseDirFiles(fset)
+		logger.Info("TYPE_LIST: ")
+		logger.Debug(spew.Sdump(tl))
+		logger.Info("STRUCT_DEFS: ")
+		logger.Debug(spew.Sdump(sm))
 		rl := relationMapper(sm, tl)
-		fmt.Println("#####STRUCT_DEFS#####")
-		spew.Dump(sm)
-		fmt.Println("######TYPE_LIST######")
-		spew.Dump(tl)
-		fmt.Println("####RELATIONSHIPS####")
-		spew.Dump(rl)
-		//_ = rl
+		logger.Info("RELATIONSHIPS: ")
+		logger.Debug(spew.Sdump(rl))
+		_ = rl
 	} else {
+		logger.Info("AST Debug Enabled!")
 		debugParseDirFiles(fset)
 	}
 }
@@ -68,7 +130,7 @@ func parseDirFiles(f *token.FileSet) (TypeList, StructMap) {
 	for _, pathVar := range pathList {
 		prse, err := parser.ParseDir(f, pathVar, fileFilter, 0)
 		if err != nil {
-			log.Fatal("Error: ", err)
+			sugar.Errorf("Error: ", err)
 		}
 		for _, pkgItem := range prse {
 			ast.Walk(VisitorFunc(FindTypes), pkgItem)
@@ -81,7 +143,7 @@ func debugParseDirFiles(f *token.FileSet) {
 	for _, pathVar := range pathList {
 		prse, err := parser.ParseDir(f, pathVar, fileFilter, 0)
 		if err != nil {
-			log.Fatal("Error: ", err)
+			sugar.Errorf("Error: ", err)
 		}
 		for _, pkgItem := range prse {
 			ast.Fprint(os.Stdout, f, pkgItem, func(name string, value reflect.Value) bool {

--- a/main.go
+++ b/main.go
@@ -95,13 +95,6 @@ func main() {
 	defer logger.Sync()
 	sugar = logger.Sugar()
 
-	//sugar.Infow("failed to fetch URL",
-	// Structured context as loosely typed key-value pairs.
-	//	"url", "http://example.com",
-	//	"attempt", 3,
-	//	"backoff", time.Second,
-	//)
-
 	logger.Info("Parsing project directory for golang files...")
 	if err := getPathList(opts.Path, visit); err != nil {
 		sugar.Errorf("filepath.Walk() returned %v\n", err)

--- a/path.go
+++ b/path.go
@@ -33,6 +33,6 @@ func fileFilter(f os.FileInfo) (rtrn bool) {
 	} else {
 		rtrn = false
 	}
-	//fmt.Printf("%s : %t\n", f.Name(), rtrn)
+	sugar.Debugf("%s : %t\n", f.Name(), rtrn)
 	return rtrn
 }

--- a/relations.go
+++ b/relations.go
@@ -19,11 +19,12 @@ func relationMapper(sm StructMap, tl TypeList) RelationList {
 	var relationList = RelationList{}
 	for ps := range sm {
 		var ptList []string
-		for _, ppt := range sm[ps].Properties {
-			//old := string(ppt[0])
-			//new := strings.ToUpper(old)
-			//appt := strings.Replace(ppt, old, new, 1)
+		sugar.Debugf("Parent Struct: %s", ps)
+		for ppn, ppt := range sm[ps].Properties {
+			sugar.Debugf("    Checking Property: %s", ppn)
+			sugar.Debugf("        Type: %s", ppt)
 			if child, ok := apptInTypeList(ppt, tl); ok != false {
+				sugar.Debugf("            Type '%s' matches requirement adding to list", ppt)
 				ptList = append(ptList, child)
 			}
 		}


### PR DESCRIPTION
- [x] allow external non StarExpr types to be recognized `alpha-0.1.2`
- [x] implement zap logger `alpha-0.1.2`
- [x] add \*ast.FuncType and \*ast.SelectorExpr to aster.go `alpha-0.1.2`
- [x] refactor processing for aster.go case statements to 'fieldType = someFunction(inputs)' `alpha-0.1.2`
- [x] create aster.go func getUndeterminedType to reduce code redundancy `alpha-0.1.2`
- [x] fix aster.go to allow support for directly nested structs `alpha-0.1.2`
- [x] add \*ast.ChanType to aster.go `alpha-0.1.2`